### PR TITLE
Fixed: error on "new" doc, hovered box bug on multiple views, view bounds check 

### DIFF
--- a/linter.lua
+++ b/linter.lua
@@ -57,7 +57,7 @@ end
 
 
 local function update_cache(doc)
-  local lints = matching_linters(doc.filename)
+  local lints = matching_linters(doc.filename or "")
   if not lints[1] then return end
 
   local d = {}

--- a/linter.lua
+++ b/linter.lua
@@ -58,13 +58,15 @@ end
 
 local function update_cache(doc)
   local d = {}
-  local path = system.absolute_path(doc.filename or "")
-  local lints = matching_linters(doc.filename)
-  for _, l in ipairs(lints) do
-    get_file_warnings(d, path, l)
-  end
-  for idx, t in pairs(d) do
-    t.line_text = doc.lines[idx]
+  if doc.filename then
+    local path = system.absolute_path(doc.filename)
+    local lints = matching_linters(doc.filename)
+    for _, l in ipairs(lints) do
+      get_file_warnings(d, path, l)
+    end
+    for idx, t in pairs(d) do
+      t.line_text = doc.lines[idx]
+    end
   end
   cache[doc] = d
 end

--- a/linter.lua
+++ b/linter.lua
@@ -113,7 +113,12 @@ function DocView:on_mouse_moved(px, py, ...)
   local cached = cache[doc]
   if not cached then return end
 
-
+  -- Check mouse is over this view
+  local x, y, w, h = self.position.x, self.position.y, self.size.x, self.size.y
+  if px < x or px > x + w or py < y or py > y + h then
+    hover_boxes[self] = nil
+    return
+  end
 
   -- Detect if any warning is hovered
   local hovered = {}

--- a/linter.lua
+++ b/linter.lua
@@ -57,16 +57,16 @@ end
 
 
 local function update_cache(doc)
+  local lints = matching_linters(doc.filename)
+  if not lints[1] then return end
+
   local d = {}
-  if doc.filename then
-    local path = system.absolute_path(doc.filename)
-    local lints = matching_linters(doc.filename)
-    for _, l in ipairs(lints) do
-      get_file_warnings(d, path, l)
-    end
-    for idx, t in pairs(d) do
-      t.line_text = doc.lines[idx]
-    end
+  local path = system.absolute_path(doc.filename)
+  for _, l in ipairs(lints) do
+    get_file_warnings(d, path, l)
+  end
+  for idx, t in pairs(d) do
+    t.line_text = doc.lines[idx]
   end
   cache[doc] = d
 end
@@ -112,6 +112,8 @@ function DocView:on_mouse_moved(px, py, ...)
   local doc = self.doc
   local cached = cache[doc]
   if not cached then return end
+
+
 
   -- Detect if any warning is hovered
   local hovered = {}

--- a/linter.lua
+++ b/linter.lua
@@ -1,7 +1,7 @@
-local core = require "core"
 local style = require "core.style"
 local config = require "core.config"
 local DocView = require "core.docview"
+local RootView = require "core.rootview"
 local Doc = require "core.doc"
 
 local cache = setmetatable({}, { __mode = "k" })
@@ -224,12 +224,10 @@ local function draw_warning_box()
 end
 
 
-local draw = DocView.draw
-function DocView:draw()
+local draw = RootView.draw
+function RootView:draw()
   draw(self)
-  if hovered_item then
-    core.root_view:defer_draw(draw_warning_box, self)
-  end
+  if hovered_item then draw_warning_box() end
 end
 
 


### PR DESCRIPTION
Fixes a few things:
* Creating a new document no longer results in an error
* A cache entry is now only made for docs which have a valid linter
* Hover boxes are now per-DocView, previously they would not behave properly with multiple views
* The mouse position is checked against the View's bounds, previously hovering over an item which was cut-off by another view would still show the box