### PR TITLE
javascript linters

### DIFF
--- a/linter_standard.lua
+++ b/linter_standard.lua
@@ -3,12 +3,12 @@
 local config = require "core.config"
 local linter = require "plugins.linter"
 
--- add auto-fixing by adding '--fix' to your options
+-- add auto-fixing by adding '--fix' to your options, add '--verbose' to get the offending eslint rule
 config.standard_args = {}
 
 linter.add_language {
   file_patterns = {"%.js$"},
   warning_pattern = "[^:]:(%d+):(%d+): ([^\n]+)",
-  command = "standard --verbose $ARGS $FILENAME",
+  command = "standard $ARGS $FILENAME",
   args = config.standard_args
 }

--- a/linter_standard.lua
+++ b/linter_standard.lua
@@ -1,0 +1,14 @@
+-- this is for standardjs linting
+
+local config = require "core.config"
+local linter = require "plugins.linter"
+
+-- add auto-fixing by adding '--fix' to your options
+config.standard_args = {}
+
+linter.add_language {
+  file_patterns = {"%.js$"},
+  warning_pattern = "[^:]:(%d+):(%d+): ([^\n]+)",
+  command = "standard --verbose $ARGS $FILENAME",
+  args = config.standard_args
+}

--- a/liter_eslint.lua
+++ b/liter_eslint.lua
@@ -1,0 +1,14 @@
+-- linter for eslint
+
+local config = require "core.config"
+local linter = require "plugins.linter"
+
+-- add --fix to your args for auto-fixing.
+config.eslint_args = {}
+
+linter.add_language {
+  file_patterns = {"%.js$"},
+  warning_pattern = "[^:]:(%d+):(%d+): ([^\n]+)",
+  command = "eslint --format unix $ARGS $FILENAME",
+  args = config.eslint_args
+}


### PR DESCRIPTION
This adds support for [standardjs](https://standardjs.com/) and [eslint](https://eslint.org/).

![Screenshot from 2020-05-10 17-33-25](https://user-images.githubusercontent.com/83857/81514542-9c422200-92e4-11ea-9689-a1e429c4264c.png)

A user doesn't really need both, but this will support either one.
