### PR TITLE
Add D-Scanner and ameba linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Linters for https://github.com/rxi/lite
 
 ## Available linters
 
+* linter\_ameba - Uses ameba for crystal files
+* linter\_dscanner - Uses dscanner for d files
 * linter\_flake8 - Uses flake8 for python files
 * linter\_gocompiler - Uses the go vet command to display compilation errors in golang files
 * linter\_golint - Uses golint for golang files

--- a/linter_ameba.lua
+++ b/linter_ameba.lua
@@ -1,0 +1,12 @@
+local core = require "core"
+local config = require "core.config"
+local linter = require "plugins.linter"
+
+config.ameba_args = {}
+
+linter.add_language {
+  file_patterns = {"%.cr$"},
+  warning_pattern = "[^:]:(%d+):(%d+)\n[%s]?([^\n]+)",
+  command = core.project_dir .. "/bin/ameba $FILENAME $ARGS --no-color",
+  args = config.ameba_args
+}

--- a/linter_dscanner.lua
+++ b/linter_dscanner.lua
@@ -1,0 +1,11 @@
+local config = require "core.config"
+local linter = require "plugins.linter"
+
+config.dscanner_args = {"-S"}
+
+linter.add_language {
+  file_patterns = {"%.d$"},
+  warning_pattern = "[^:]%((%d+):(%d+)%)[%s]?([^\n]+)",
+  command = "dscanner $FILENAME $ARGS",
+  args = config.dscanner_args
+}


### PR DESCRIPTION
This PR adds support for [D-Scanner](https://github.com/dlang-community/D-Scanner/) and [ameba](https://github.com/crystal-ameba/ameba)