### PR TITLE
Added redirection to linter_golint

### DIFF
--- a/linter_golint.lua
+++ b/linter_golint.lua
@@ -6,7 +6,6 @@ config.golint_args = {}
 linter.add_language {
   file_patterns = {"%.go$"},
   warning_pattern = "[^:]:(%d+):(%d+):%s?([^\n]*)",
-  command = "golint $ARGS $FILENAME",
+  command = "golint $ARGS $FILENAME 2>&1",
   args = config.golint_args
 }
-


### PR DESCRIPTION
Hello. Since `golint` writes all errors and warnings to *STDERR*, a redirection is necessary in the command ( just like in *linter_gocompiler.lua* )

Reach out if you have any questions. Thanks!