### PR TITLE
Fix Go Linters

### DIFF
--- a/linter.lua
+++ b/linter.lua
@@ -28,16 +28,19 @@ end
 local function get_file_warnings(warnings, path, linter)
   local w_text = run_lint_cmd(path, linter)
   local pattern = linter.warning_pattern
-  for line, col, warn in w_text:gmatch(pattern) do
-    line = tonumber(line)
-    col = tonumber(col)
-    if not warnings[line] then
-      warnings[line] = {}
+  for w_path, line, col, warn in w_text:gmatch(pattern) do
+    local i = path:find(w_path:sub(2))
+    if i ~= nil then
+      line = tonumber(line)
+      col = tonumber(col)
+      if not warnings[line] then
+        warnings[line] = {}
+      end
+      local w = {}
+      w.col = col
+      w.text = warn
+      table.insert(warnings[line], w)
     end
-    local w = {}
-    w.col = col
-    w.text = warn
-    table.insert(warnings[line], w)
   end
 end
 

--- a/linter_eslint.lua
+++ b/linter_eslint.lua
@@ -8,7 +8,7 @@ config.eslint_args = {}
 
 linter.add_language {
   file_patterns = {"%.js$"},
-  warning_pattern = "[^:]:(%d+):(%d+): ([^\n]+)",
+  warning_pattern = "([^:]+):(%d+):(%d+): ([^\n]+)",
   command = "eslint --format unix $ARGS $FILENAME",
   args = config.eslint_args
 }

--- a/linter_flake8.lua
+++ b/linter_flake8.lua
@@ -5,7 +5,7 @@ config.flake8_args = {}
 
 linter.add_language {
   file_patterns = {"%.py$"},
-  warning_pattern = "[^:]:(%d+):(%d+):%s[%w]+%s([^\n]*)",
+  warning_pattern = "([^:]+):(%d+):(%d+):%s[%w]+%s([^\n]*)",
   command = "flake8 $ARGS $FILENAME",
   args = config.flake8_args
 }

--- a/linter_golint.lua
+++ b/linter_golint.lua
@@ -5,8 +5,8 @@ config.golint_args = {}
 
 linter.add_language {
   file_patterns = {"%.go$"},
-  warning_pattern = "[^:]:(%d+):(%d+):%s?([^\n]*)",
-  command = "golint $ARGS $FILENAME",
+  warning_pattern = "([^:]+):(%d+):(%d+):%s?([^\n]*)",
+  command = "golint $ARGS ./...",
   args = config.golint_args
 }
 

--- a/linter_gostaticcheck.lua
+++ b/linter_gostaticcheck.lua
@@ -1,0 +1,8 @@
+local linter = require "plugins.linter"
+
+linter.add_language {
+  file_patterns = {"%.go$"},
+  warning_pattern = "([^:]+):(%d+):(%d+):%s?([^\n]*)",
+  command = "staticcheck ./...",
+  args = {}
+}

--- a/linter_govet.lua
+++ b/linter_govet.lua
@@ -2,7 +2,7 @@ local linter = require "plugins.linter"
 
 linter.add_language {
   file_patterns = {"%.go$"},
-  warning_pattern = "[^:]:(%d+):(%d+):[%s]?([^\n]+)",
-  command = "go vet -source $FILENAME 2>&1",
+  warning_pattern = "([^:]+):(%d+):(%d+):%s?([^\n]*)",
+  command = "go vet -source ./... 2>&1",
   args = {}
 }

--- a/linter_luacheck.lua
+++ b/linter_luacheck.lua
@@ -5,7 +5,7 @@ config.luacheck_args = {}
 
 linter.add_language {
   file_patterns = {"%.lua$"},
-  warning_pattern = "[^:]:(%d+):(%d+):[%s]?([^\n]+)",
+  warning_pattern = "([^:]+):(%d+):(%d+):[%s]?([^\n]+)",
   command = "luacheck $FILENAME --formatter=plain $ARGS",
   args = config.luacheck_args
 }

--- a/linter_standard.lua
+++ b/linter_standard.lua
@@ -8,7 +8,7 @@ config.standard_args = {}
 
 linter.add_language {
   file_patterns = {"%.js$"},
-  warning_pattern = "[^:]:(%d+):(%d+): ([^\n]+)",
+  warning_pattern = "([^:]+):(%d+):(%d+): ([^\n]+)",
   command = "standard $ARGS $FILENAME",
   args = config.standard_args
 }


### PR DESCRIPTION
Since Go was the only linter in the list that is a static language the linter didn't actually work correctly since linting needs to analyze the entire codebase for proper warnings. Linting just a single file only showed part of the warnings or false warnings. Within a package if a constant variable was defined in `mypackage/file_a.go` and it was used in `mypackage/file_b.go` and we only ran golint against `mypackage/file_b.go` it would warn us of an undefined variable which is not the case since the constant was defined within the package, but in a different file.

This PR now pattern matches the output of the linters and includes the path of the file the warning occurs so the main function that paints the warnings can check if the current document has any warnings. If it does it will only add those to the table to be painted.

I updated the rest of the linters so the `w_path` would return from the `gmatch` call to keep it generic.

I also added https://staticcheck.io as another Go linter since this is much more popular than `golint` is.