### PR TITLE
Add ability to specify order of warning_pattern order and added php linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Linters for https://github.com/rxi/lite
 * linter\_gocompiler - Uses the go vet command to display compilation errors in golang files
 * linter\_golint - Uses golint for golang files
 * linter\_luacheck - Uses luacheck for lua files
+* linter\_php - Uses built-in php binary -l flag for php files
 * linter\_shellcheck - Uses shellcheck linter for shell script files
 * linter\_standard - Uses standard linter for javascript files
 

--- a/linter.lua
+++ b/linter.lua
@@ -33,36 +33,19 @@ local function match_pattern(text, pattern, order)
 
   return coroutine.wrap(function()
     for one, two, three in text:gmatch(pattern) do
-      local line, col, warn
+      local fields = {one, two, three}
+      local ordered = {line = 1, col = 1, message = "syntax error"}
       for field,position in pairs(order) do
-        local value
-        if position == 1 then
-          value = one
-        elseif position == 2 then
-          value = two
-        elseif position == 3 then
-          value = three
-        end
-
-        if field == "line" then
-          line = value
-        elseif field == "col" then
-          col = value
-        elseif field == "message" then
-          warn = value
+        ordered[field] = fields[position] or ordered[field]
+        if
+          field == "line"
+          and current_doc ~= nil
+          and tonumber(ordered[field]) > #current_doc.lines
+        then
+          ordered[field] = #current_doc.lines
         end
       end
-
-      if line == nil then line = 1 end
-      if col == nil then col = 1 end
-      if warn == nil then warn = "syntax error" end
-
-      if current_doc ~= nil then
-        if tonumber(line) > #current_doc.lines then
-          line = #current_doc.lines
-        end
-      end
-      coroutine.yield(line, col, warn)
+      coroutine.yield(ordered.line, ordered.col, ordered.message)
     end
   end)
 end

--- a/linter_php.lua
+++ b/linter_php.lua
@@ -1,0 +1,12 @@
+local config = require "core.config"
+local linter = require "plugins.linter"
+
+config.phplint_args = {}
+
+linter.add_language {
+  file_patterns = {"%.php$"},
+  warning_pattern = "[%a ]+:%s*(.*)%s+on%sline%s+(%d+)",
+  warning_pattern_order = {line=2, col=nil, message=1},
+  command = "php -l $ARGS $FILENAME 2>/dev/null",
+  args = config.phplint_args
+}


### PR DESCRIPTION
Added the ability to specify the warning pattern order as follows:

```lua
linter.add_language {
  file_patterns = {"%.php$"},
  warning_pattern = "[%a ]+:%s*(.*)%s+on%sline%s+(%d+)",
  warning_pattern_order = {line=2, col=nil, message=1},
  command = "php -l $ARGS $FILENAME 2>/dev/null",
  args = config.phplint_args
}
```
Since the php built-in linter doesn't returns the column number you can specify nil on any of the fields (line, col, message) and it will be set to 1 for line or col and by "syntax error" for message.