### PR TITLE
Add nim check support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Linters for https://github.com/rxi/lite
 * linter\_gocompiler - Uses the go vet command to display compilation errors in golang files
 * linter\_golint - Uses golint for golang files
 * linter\_luacheck - Uses luacheck for lua files
+* linter\_nim - Uses nim check for nim files
 * linter\_php - Uses built-in php binary -l flag for php files
 * linter\_shellcheck - Uses shellcheck linter for shell script files
 * linter\_standard - Uses standard linter for javascript files

--- a/linter_nim.lua
+++ b/linter_nim.lua
@@ -1,8 +1,16 @@
 local linter = require "plugins.linter"
 
+local pattern
+if PLATFORM == "Windows" then
+  -- TODO: For now in windows we only display single line warnings
+  pattern = [[$FILENAME%((%d+), (%d+)%)([^\n]+)]]
+else
+  pattern = [[$FILENAME%((%d+), (%d+)%)([^\n]+[^/]*)]]
+end
+
 linter.add_language {
   file_patterns = {"%.nim$", "%.nims$"},
-  warning_pattern = [[$FILENAME%((%d+), (%d+)%)([^\n]+[^\//]*)]],
-  command = "nim check $FILENAME 2>&1",
+  warning_pattern = pattern,
+  command = "nim --listfullpaths --stdout check $FILENAME",
   deduplicate = true
 }

--- a/linter_nim.lua
+++ b/linter_nim.lua
@@ -2,8 +2,25 @@ local linter = require "plugins.linter"
 
 local pattern
 if PLATFORM == "Windows" then
-  -- TODO: For now in windows we only display single line warnings
-  pattern = [[$FILENAME%((%d+), (%d+)%)([^\n]+)]]
+  pattern = function(text, filename)
+    local line, col, warn
+    for line_text in text:gmatch("[^\n]+") do
+      local has_path = line_text:match("[A-Z]:\\")
+      local has_filename = line_text:match(filename)
+      if has_path then
+        if warn then coroutine.yield(line, col, warn) end
+        if has_filename then
+          line, col, warn = line_text:match("%((%d+), (%d+)%)([^\n]+)")
+        else
+          warn = nil -- New warning found but about another file
+        end
+      else
+        if warn then warn = warn.."\n"..line_text end
+      end
+      -- When we reach the end of the lines we didn't report the last warning
+      if warn then coroutine.yield(line, col, warn) end
+    end
+  end
 else
   pattern = [[$FILENAME%((%d+), (%d+)%)([^\n]+[^/]*)]]
 end

--- a/linter_nim.lua
+++ b/linter_nim.lua
@@ -1,0 +1,8 @@
+local linter = require "plugins.linter"
+
+linter.add_language {
+  file_patterns = {"%.nim$", "%.nims$"},
+  warning_pattern = [[$FILENAME%((%d+), (%d+)%)([^\n]+[^\//]*)]],
+  command = "nim check $FILENAME 2>&1",
+  deduplicate = true
+}


### PR DESCRIPTION
Started by @Jipok in #15 .

`nim check` reports warnings/errors/hints of multiple files. To solve this the possibility to use $FILENAME was added in the matching pattern.

`nim check` also reports multiple times the same error in the same line/col. To address this problem, the possibility to run de-duplication in the warnings of the linters was added.

With this $FILENAME in the matching pattern it would allow for possible injections in the pattern, so escaping was implemented for this case.
