### PR TITLE
Add pylint linter for python files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Linters for https://github.com/rxi/lite
 * linter\_luacheck - Uses luacheck for lua files
 * linter\_nim - Uses nim check for nim files
 * linter\_php - Uses built-in php binary -l flag for php files
+* linter\_pylint - Uses pylint for python files
 * linter\_shellcheck - Uses shellcheck linter for shell script files
 * linter\_standard - Uses standard linter for javascript files
 

--- a/linter_pylint.lua
+++ b/linter_pylint.lua
@@ -1,0 +1,32 @@
+local config = require "core.config"
+local linter = require "plugins.linter"
+
+config.pylint_args = {}
+
+local pattern = function(text, filename)
+  local line, col, warn, path, l, c, w
+  for line_text in text:gmatch("[^\n]+") do
+    -- Default pylint format: {path}:{line}:{column}: {msg_id}: {msg} ({symbol})
+    path, l, c, w = line_text:match("([^:]):(%d+):(%d+):%s([%w]+:%s[^\n]*)")
+    local has_filename = path and filename:match(linter.escape_to_pattern(path))
+    if path then
+      if warn then -- End of the last warning
+        coroutine.yield(line, col, warn)
+        warn = nil
+      end
+      -- Pylint reports columns as zero-based, linter.lua expects one-based
+      if has_filename then line, col, warn = l, tonumber(c)+1, w end
+    else
+      if warn then warn = warn.."\n"..line_text end
+    end
+  end
+  -- When we reach the end of the lines we didn't report the last warning
+  if warn then coroutine.yield(line, col, warn) end
+end
+
+linter.add_language {
+  file_patterns = {"%.py$"},
+  warning_pattern = pattern,
+  command = "pylint --score=n $ARGS $FILENAME", -- Disabled score output
+  args = config.pylint_args
+}

--- a/linter_pylint.lua
+++ b/linter_pylint.lua
@@ -3,30 +3,10 @@ local linter = require "plugins.linter"
 
 config.pylint_args = {}
 
-local pattern = function(text, filename)
-  local line, col, warn, path, l, c, w
-  for line_text in text:gmatch("[^\n]+") do
-    -- Default pylint format: {path}:{line}:{column}: {msg_id}: {msg} ({symbol})
-    path, l, c, w = line_text:match("([^:]):(%d+):(%d+):%s([%w]+:%s[^\n]*)")
-    local has_filename = path and filename:match(linter.escape_to_pattern(path))
-    if path then
-      if warn then -- End of the last warning
-        coroutine.yield(line, col, warn)
-        warn = nil
-      end
-      -- Pylint reports columns as zero-based, linter.lua expects one-based
-      if has_filename then line, col, warn = l, tonumber(c)+1, w end
-    else
-      if warn then warn = warn.."\n"..line_text end
-    end
-  end
-  -- When we reach the end of the lines we didn't report the last warning
-  if warn then coroutine.yield(line, col, warn) end
-end
-
 linter.add_language {
   file_patterns = {"%.py$"},
-  warning_pattern = pattern,
+  warning_pattern = "[^:]:(%d+):(%d+):%s([%w]+:%s[^\n]*)", -- Default pylint format
+  column_starts_at_zero = true,
   command = "pylint --score=n $ARGS $FILENAME", -- Disabled score output
   args = config.pylint_args
 }


### PR DESCRIPTION
Here is a linter lua script for `pylint`. I used existing linters `linter_flake8.lua` and `linter_gocompiler.lua` as a basis for this script. I'm not a Lua developer so further edits are welcome.